### PR TITLE
Added faster method for username retrieval.

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,6 +202,29 @@ def init():
 	print('Ready!\n\n--------------COMMANDS--------------')
 
 
+def login_fast():
+	from robobrowser import RoboBrowser
+	from bs4 import BeautifulSoup as bs
+
+	browser = RoboBrowser(history=True)
+	browser.open('https://m.facebook.com/')
+	#FORM FILL
+	form = browser.get_form()
+	form['email'].value=mail
+	form['pass'].value=password
+	browser.submit_form(form)
+	#PARSER (can also be implemented from robobrowser)
+	soup = browser.parsed
+	try:
+		soup = soup.find("label", {"for" : "u_0_0"})
+		username = soup.a
+		username.clear()
+		username = str(username)
+		profile = username[username.find('/')+1 : username.find('?')]
+		#print (profile)
+	except:
+		print("wrong credentials!")
+
 if __name__ == '__main__':
 	init()
 	while True:


### PR DESCRIPTION
Please refer to `https://github.com/dhruvramani/Terminal-on-FB-Messenger/issues/1`
I've added `https://gist.github.com/manu-chroma/8c5b39bef7335fa23a6f` as a function and leave it upto the owner to integrate it accordingly.
Fully compatible with `python3` this time.
P.S:
After obtaining the username, you can directly request `https://facebook.com/messages/<profile>` which will redirect to `https://facebook.com/login.php` and then redirect to the initial link after login.
